### PR TITLE
mysqlコンテナ作成できないエラーとコンテナ起動後落ちてしまうエラー解消

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
     build: # Dockerfileで設定する
       context: .
       dockerfile: ./docker/mysql/Dockerfile
-    command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_DATABASE=posse

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,12 +1,19 @@
-FROM --platform=linux/x86_64 mysql:8-debian
-# 言語設定を変えるためにパッケージをインストール
-RUN apt-get update
-RUN apt-get -y install locales-all
-# MySQLを日本語に対応させる
+FROM mysql:8
+
+# Oracle Linux のためのパッケージマネージャーのインストール
+USER root
+RUN microdnf install -y glibc-locale-source glibc-langpack-en
+
+# 日本語ロケールの生成と設定
+RUN localedef -i ja_JP -f UTF-8 ja_JP.UTF-8
+
+# 環境変数の設定
 ENV LANG ja_JP.UTF-8
-ENV LANGUAGE ja_JP:ja
 ENV LC_ALL ja_JP.UTF-8
 # タイムゾーン(東京)
 ENV TZ Asia/Tokyo
 # MySQLのconfigファイル(my.cnf)をコピー
 COPY ./docker/mysql/my.cnf /etc/my.cnf
+
+# キャッシュと不要なファイルの削除
+RUN microdnf clean all

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -2,7 +2,6 @@
 user=mysql
 character_set_server = utf8mb4
 collation_server = utf8mb4_0900_ai_ci
-# MySQL8.0の認証方式にPHP側では対応していないので従来の認証方式に変える
 mysql_native_password=on
 
 # timezone

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -3,7 +3,7 @@ user=mysql
 character_set_server = utf8mb4
 collation_server = utf8mb4_0900_ai_ci
 # MySQL8.0の認証方式にPHP側では対応していないので従来の認証方式に変える
-default_authentication_plugin=mysql_native_password
+mysql_native_password=on
 
 # timezone
 default-time-zone = SYSTEM


### PR DESCRIPTION
## 起きてた問題
- そもそも`docker compose up -d`ができない
  - mysqlのコンテナでエラー出ている
  - こちらに関しては、discordに解決方法が共有されていた
  - 共有されてはいたが、templateに反映されていなかった
- docker compose up -d ができても、mysqlのコンテナが起動後落ちてしまう
  - エラー内容
```
 [ERROR] [MY-000067] [Server] unknown variable 'default_authentication_plugin=mysql_native_password'.
2024-06-29 17:43:24 2024-06-29T17:43:24.797882+09:00 0 [ERROR] [MY-010119] [Server] Aborting
2024-06-29 17:43:26 2024-06-29T17:43:26.343060+09:00 0 [System] [MY-010910] [Server] /usr/sbin/mysqld: Shutdown complete (mysqld 8.4.0)  MySQL Community Server - GPL.
2024-06-29 17:43:26 2024-06-29T17:43:26.343150+09:00 0 [System] [MY-015016] [Server] MySQL Server - end.
``` 
  - `default_authentication_plugin`らへんがエラー原因ぽい...

## 解決策
- discordの解決策をtemplateに反映
- `default_authentication_plugin`らへんを修正

### 参考
[MySQL 8.4-LTSがやってきた＆native_passwordに注意](https://sakaik.hateblo.jp/entry/20240430/mysql_8_4_0_lts_is_coming)

[discord上の会話](https://discord.com/channels/1011180011732086825/1011180767084294174/1256530266520948859)